### PR TITLE
Add support for custom DISTRIBUTION metric

### DIFF
--- a/lib/statix.ex
+++ b/lib/statix.ex
@@ -226,6 +226,24 @@ defmodule Statix do
   @callback timing(key, value :: String.Chars.t(), options) :: on_send
 
   @doc """
+  Same as `distribution(key, value, [])`.
+  """
+  @callback distribution(key, value :: String.Chars.t()) :: on_send
+
+  @doc """
+  Writes the given `value` to the StatsD distribution identified by `key`.
+
+  `value` is expected in milliseconds.
+
+  ## Examples
+
+      iex> MyApp.Statix.distribution("rendering", 12, [])
+      :ok
+
+  """
+  @callback distribution(key, value :: String.Chars.t(), options) :: on_send
+
+  @doc """
   Writes the given `value` to the StatsD set identified by `key`.
 
   ## Examples
@@ -330,6 +348,10 @@ defmodule Statix do
         Statix.transmit(current_statix(), :timing, key, val, options)
       end
 
+      def distribution(key, val, options \\ []) do
+        Statix.transmit(current_statix(), :distribution, key, val, options)
+      end
+
       def measure(key, options \\ [], fun) when is_function(fun, 0) do
         {elapsed, result} = :timer.tc(fun)
 
@@ -349,7 +371,8 @@ defmodule Statix do
         histogram: 3,
         timing: 3,
         measure: 3,
-        set: 3
+        set: 3,
+        distribution: 3
       )
     end
   end

--- a/lib/statix/packet.ex
+++ b/lib/statix/packet.ex
@@ -35,7 +35,8 @@ defmodule Statix.Packet do
     gauge: "g",
     histogram: "h",
     timing: "ms",
-    set: "s"
+    set: "s",
+    distribution: "d"
   }
 
   for {name, type} <- metrics do

--- a/test/statix/overriding_test.exs
+++ b/test/statix/overriding_test.exs
@@ -35,6 +35,10 @@ defmodule Statix.OverridingTest do
     super([key, "-overridden"], value, options)
   end
 
+  def distribution(key, value, options) do
+    super([key, "-overridden"], value, options)
+  end
+
   setup do
     connect()
   end
@@ -62,6 +66,11 @@ defmodule Statix.OverridingTest do
   test "timing/3" do
     timing("sample", 3, tags: ["foo"])
     assert_receive {:test_server, _, "sample-overridden:3|ms|#foo"}
+  end
+
+  test "distribution/3" do
+    distribution("sample", 3, tags: ["foo"])
+    assert_receive {:test_server, _, "sample-overridden:3|d|#foo"}
   end
 
   test "measure/3" do

--- a/test/statix/pool_test.exs
+++ b/test/statix/pool_test.exs
@@ -20,7 +20,8 @@ defmodule Statix.PoolingTest do
         {:histogram, [3]},
         {:timing, [3]},
         {:measure, [fn -> nil end]},
-        {:set, [3]}
+        {:set, [3]},
+        {:distribution, [3]}
       ]
       |> Enum.map(fn {function, arguments} ->
         apply(__MODULE__, function, ["sample" | arguments])

--- a/test/statix_test.exs
+++ b/test/statix_test.exs
@@ -153,6 +153,24 @@ defmodule StatixTest do
     refute_received _any
   end
 
+  test "distribution/2,3" do
+    __MODULE__.distribution(["sample"], 2)
+    assert_receive {:test_server, _, "sample:2|d"}
+
+    distribution("sample", 2.1)
+    assert_receive {:test_server, _, "sample:2.1|d"}
+
+    distribution("sample", 3, tags: ["foo:bar", "baz"])
+    assert_receive {:test_server, _, "sample:3|d|#foo:bar,baz"}
+
+    distribution("sample", 3, sample_rate: 1.0, tags: ["foo", "bar"])
+    assert_receive {:test_server, _, "sample:3|d|@1.0|#foo,bar"}
+
+    distribution("sample", 3, sample_rate: 0.0)
+
+    refute_received _any
+  end
+
   test "port closed" do
     close_port()
 
@@ -175,5 +193,9 @@ defmodule StatixTest do
     assert capture_log(fn ->
              assert {:error, :port_closed} == timing("sample", 2.5)
            end) =~ "timing metric \"sample\" lost value 2.5 due to port closure"
+
+    assert capture_log(fn ->
+             assert {:error, :port_closed} == distribution("sample", 2.5)
+           end) =~ "distribution metric \"sample\" lost value 2.5 due to port closure"
   end
 end


### PR DESCRIPTION
Example of usage follows:

    iex> MyApp.Statix.distribution("rendering", 12, [])
    :ok

From the Datadog documentation:

> Unlike the HISTOGRAM metric type, which aggregates on the Agent during
a given time interval, a DISTRIBUTION metric sends all the raw data during a time interval to Datadog, and aggregations occur server-side. Because the underlying data structure represents raw, unaggregated data, distributions provide two major features:
>
>  - Calculation of percentile aggregations
>  - Customization of tagging

https://docs.datadoghq.com/developers/metrics/types/?tab=distribution#definition

Closes #46